### PR TITLE
Refactoring: macros and exceptions (#11)

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -13,7 +13,7 @@
     }
   ],
   "syntax": {
-    "version": "v702",
+    "version": "v740sp02",
     "errorNamespace": "^(Z|Y)",
     "globalConstants": [],
     "globalMacros": []
@@ -111,7 +111,7 @@
     "check_syntax": true,
     "class_attribute_names": {
       "ignoreExceptions": true,
-      "statics": "^G._.*$",
+      "statics": "^M._.*$",
       "constants": "",
       "ignoreInterfaces": false,
       "ignoreLocal": false,
@@ -268,7 +268,7 @@
     },
     "release_idoc": true,
     "remove_descriptions": {
-      "ignoreExceptions": false,
+      "ignoreExceptions": true,
       "ignoreWorkflow": false
     },
     "rfc_error_handling": false,
@@ -285,7 +285,7 @@
     "space_before_colon": true,
     "space_before_dot": true,
     "start_at_tab": true,
-    "superclass_final": true,
+    "superclass_final": false,
     "tabl_enhancement_category": true,
     "type_form_parameters": true,
     "unreachable_code": true,

--- a/src/zcl_des.clas.abap
+++ b/src/zcl_des.clas.abap
@@ -11,6 +11,8 @@ CLASS zcl_des DEFINITION
     TYPES:
       ty_byte8 TYPE x LENGTH 8 .
 
+    CLASS-METHODS class_constructor.
+
     CLASS-METHODS decrypt
       IMPORTING
         !iv_key             TYPE ty_byte8
@@ -28,10 +30,36 @@ CLASS zcl_des DEFINITION
         !iv_byte7       TYPE ty_byte7
       RETURNING
         VALUE(rv_byte8) TYPE ty_byte8 .
+
   PROTECTED SECTION.
+
+    TYPES:
 *"* protected components of class ZCL_DES
 *"* do not include other source files here!!!
+      tty_itab TYPE STANDARD TABLE OF i WITH DEFAULT KEY .
+  PRIVATE SECTION.
 
+    CLASS-DATA mt_e TYPE tty_itab .
+    CLASS-DATA mt_ip TYPE tty_itab .
+    CLASS-DATA mt_ip1 TYPE tty_itab .
+    CLASS-DATA mt_p TYPE tty_itab .
+    CLASS-DATA mt_pc1 TYPE tty_itab .
+    CLASS-DATA mt_pc2 TYPE tty_itab .
+    CLASS-DATA mt_s1 TYPE tty_itab .
+    CLASS-DATA mt_s2 TYPE tty_itab .
+    CLASS-DATA mt_s3 TYPE tty_itab .
+    CLASS-DATA mt_s4 TYPE tty_itab .
+    CLASS-DATA mt_s5 TYPE tty_itab .
+    CLASS-DATA mt_s6 TYPE tty_itab .
+    CLASS-DATA mt_s7 TYPE tty_itab .
+    CLASS-DATA mt_s8 TYPE tty_itab .
+
+    CLASS-METHODS permute
+      IMPORTING
+        !iv_bits        TYPE clike
+        !it_permutation TYPE tty_itab
+      RETURNING
+        VALUE(rv_bits)  TYPE string .
     CLASS-METHODS xor
       IMPORTING
         !iv_a         TYPE clike
@@ -157,7 +185,6 @@ CLASS zcl_des DEFINITION
         !iv_b            TYPE clike
       RETURNING
         VALUE(rv_column) TYPE i .
-  PRIVATE SECTION.
 *"* private components of class ZCL_DES
 *"* do not include other source files here!!!
 ENDCLASS.
@@ -167,81 +194,171 @@ ENDCLASS.
 CLASS ZCL_DES IMPLEMENTATION.
 
 
+  METHOD class_constructor.
+    mt_e = VALUE #(
+      ( 32 ) ( 1 ) ( 2 ) ( 3 ) ( 4 ) ( 5 ) ( 4 ) ( 5 )
+      ( 6 ) ( 7 ) ( 8 ) ( 9 ) ( 8 ) ( 9 ) ( 10 ) ( 11 )
+      ( 12 ) ( 13 ) ( 12 ) ( 13 ) ( 14 ) ( 15 ) ( 16 ) ( 17 )
+      ( 16 ) ( 17 ) ( 18 ) ( 19 ) ( 20 ) ( 21 ) ( 20 ) ( 21 )
+      ( 22 ) ( 23 ) ( 24 ) ( 25 ) ( 24 ) ( 25 ) ( 26 ) ( 27 )
+      ( 28 ) ( 29 ) ( 28 ) ( 29 ) ( 30 ) ( 31 ) ( 32 ) ( 1 ) ).
+
+    mt_ip = VALUE #(
+      ( 58 ) ( 50 ) ( 42 ) ( 34 ) ( 26 ) ( 18 ) ( 10 ) ( 2 )
+      ( 60 ) ( 52 ) ( 44 ) ( 36 ) ( 28 ) ( 20 ) ( 12 ) ( 4 )
+      ( 62 ) ( 54 ) ( 46 ) ( 38 ) ( 30 ) ( 22 ) ( 14 ) ( 6 )
+      ( 64 ) ( 56 ) ( 48 ) ( 40 ) ( 32 ) ( 24 ) ( 16 ) ( 8 )
+      ( 57 ) ( 49 ) ( 41 ) ( 33 ) ( 25 ) ( 17 ) ( 9 ) ( 1 )
+      ( 59 ) ( 51 ) ( 43 ) ( 35 ) ( 27 ) ( 19 ) ( 11 ) ( 3 )
+      ( 61 ) ( 53 ) ( 45 ) ( 37 ) ( 29 ) ( 21 ) ( 13 ) ( 5 )
+      ( 63 ) ( 55 ) ( 47 ) ( 39 ) ( 31 ) ( 23 ) ( 15 ) ( 7 ) ).
+
+    mt_ip1 = VALUE #(
+      ( 40 ) ( 8 ) ( 48 ) ( 16 ) ( 56 ) ( 24 ) ( 64 ) ( 32 )
+      ( 39 ) ( 7 ) ( 47 ) ( 15 ) ( 55 ) ( 23 ) ( 63 ) ( 31 )
+      ( 38 ) ( 6 ) ( 46 ) ( 14 ) ( 54 ) ( 22 ) ( 62 ) ( 30 )
+      ( 37 ) ( 5 ) ( 45 ) ( 13 ) ( 53 ) ( 21 ) ( 61 ) ( 29 )
+      ( 36 ) ( 4 ) ( 44 ) ( 12 ) ( 52 ) ( 20 ) ( 60 ) ( 28 )
+      ( 35 ) ( 3 ) ( 43 ) ( 11 ) ( 51 ) ( 19 ) ( 59 ) ( 27 )
+      ( 34 ) ( 2 ) ( 42 ) ( 10 ) ( 50 ) ( 18 ) ( 58 ) ( 26 )
+      ( 33 ) ( 1 ) ( 41 ) ( 9 ) ( 49 ) ( 17 ) ( 57 ) ( 25 ) ).
+
+    mt_p = VALUE #(
+      ( 16 ) ( 7 ) ( 20 ) ( 21 ) ( 29 ) ( 12 ) ( 28 ) ( 17 )
+      ( 1 ) ( 15 ) ( 23 ) ( 26 ) ( 5 ) ( 18 ) ( 31 ) ( 10 )
+      ( 2 ) ( 8 ) ( 24 ) ( 14 ) ( 32 ) ( 27 ) ( 3 ) ( 9 )
+      ( 19 ) ( 13 ) ( 30 ) ( 6 ) ( 22 ) ( 11 ) ( 4 ) ( 25 ) ).
+
+    mt_pc1 = VALUE #(
+      ( 57 ) ( 49 ) ( 41 ) ( 33 ) ( 25 ) ( 17 ) ( 9 ) ( 1 )
+      ( 58 ) ( 50 ) ( 42 ) ( 34 ) ( 26 ) ( 18 ) ( 10 ) ( 2 )
+      ( 59 ) ( 51 ) ( 43 ) ( 35 ) ( 27 ) ( 19 ) ( 11 ) ( 3 )
+      ( 60 ) ( 52 ) ( 44 ) ( 36 ) ( 63 ) ( 55 ) ( 47 ) ( 39 )
+      ( 31 ) ( 23 ) ( 15 ) ( 7 ) ( 62 ) ( 54 ) ( 46 ) ( 38 )
+      ( 30 ) ( 22 ) ( 14 ) ( 6 ) ( 61 ) ( 53 ) ( 45 ) ( 37 )
+      ( 29 ) ( 21 ) ( 13 ) ( 5 ) ( 28 ) ( 20 ) ( 12 ) ( 4 ) ).
+
+    mt_pc2 = VALUE #(
+      ( 14 ) ( 17 ) ( 11 ) ( 24 ) ( 1 ) ( 5 ) ( 3 ) ( 28 )
+      ( 15 ) ( 6 ) ( 21 ) ( 10 ) ( 23 ) ( 19 ) ( 12 ) ( 4 )
+      ( 26 ) ( 8 ) ( 16 ) ( 7 ) ( 27 ) ( 20 ) ( 13 ) ( 2 )
+      ( 41 ) ( 52 ) ( 31 ) ( 37 ) ( 47 ) ( 55 ) ( 30 ) ( 40 )
+      ( 51 ) ( 45 ) ( 33 ) ( 48 ) ( 44 ) ( 49 ) ( 39 ) ( 56 )
+      ( 34 ) ( 53 ) ( 46 ) ( 42 ) ( 50 ) ( 36 ) ( 29 ) ( 32 ) ).
+
+    mt_s1 = VALUE #(
+      ( 14 ) ( 4 ) ( 13 ) ( 1 ) ( 2 ) ( 15 ) ( 11 ) ( 8 )
+      ( 3 ) ( 10 ) ( 6 ) ( 12 ) ( 5 ) ( 9 ) ( 0 ) ( 7 )
+      ( 0 ) ( 15 ) ( 7 ) ( 4 ) ( 14 ) ( 2 ) ( 13 ) ( 1 )
+      ( 10 ) ( 6 ) ( 12 ) ( 11 ) ( 9 ) ( 5 ) ( 3 ) ( 8 )
+      ( 4 ) ( 1 ) ( 14 ) ( 8 ) ( 13 ) ( 6 ) ( 2 ) ( 11 )
+      ( 15 ) ( 12 ) ( 9 ) ( 7 ) ( 3 ) ( 10 ) ( 5 ) ( 0 )
+      ( 15 ) ( 12 ) ( 8 ) ( 2 ) ( 4 ) ( 9 ) ( 1 ) ( 7 )
+      ( 5 ) ( 11 ) ( 3 ) ( 14 ) ( 10 ) ( 0 ) ( 6 ) ( 13 ) ).
+
+    mt_s2 = VALUE #(
+      ( 15 ) ( 1 ) ( 8 ) ( 14 ) ( 6 ) ( 11 ) ( 3 ) ( 4 )
+      ( 9 ) ( 7 ) ( 2 ) ( 13 ) ( 12 ) ( 0 ) ( 5 ) ( 10 )
+      ( 3 ) ( 13 ) ( 4 ) ( 7 ) ( 15 ) ( 2 ) ( 8 ) ( 14 )
+      ( 12 ) ( 0 ) ( 1 ) ( 10 ) ( 6 ) ( 9 ) ( 11 ) ( 5 )
+      ( 0 ) ( 14 ) ( 7 ) ( 11 ) ( 10 ) ( 4 ) ( 13 ) ( 1 )
+      ( 5 ) ( 8 ) ( 12 ) ( 6 ) ( 9 ) ( 3 ) ( 2 ) ( 15 )
+      ( 13 ) ( 8 ) ( 10 ) ( 1 ) ( 3 ) ( 15 ) ( 4 ) ( 2 )
+      ( 11 ) ( 6 ) ( 7 ) ( 12 ) ( 0 ) ( 5 ) ( 14 ) ( 9 ) ).
+
+    mt_s3 = VALUE #(
+      ( 10 ) ( 0 ) ( 9 ) ( 14 ) ( 6 ) ( 3 ) ( 15 ) ( 5 )
+      ( 1 ) ( 13 ) ( 12 ) ( 7 ) ( 11 ) ( 4 ) ( 2 ) ( 8 )
+      ( 13 ) ( 7 ) ( 0 ) ( 9 ) ( 3 ) ( 4 ) ( 6 ) ( 10 )
+      ( 2 ) ( 8 ) ( 5 ) ( 14 ) ( 12 ) ( 11 ) ( 15 ) ( 1 )
+      ( 13 ) ( 6 ) ( 4 ) ( 9 ) ( 8 ) ( 15 ) ( 3 ) ( 0 )
+      ( 11 ) ( 1 ) ( 2 ) ( 12 ) ( 5 ) ( 10 ) ( 14 ) ( 7 )
+      ( 1 ) ( 10 ) ( 13 ) ( 0 ) ( 6 ) ( 9 ) ( 8 ) ( 7 )
+      ( 4 ) ( 15 ) ( 14 ) ( 3 ) ( 11 ) ( 5 ) ( 2 ) ( 12 ) ).
+
+    mt_s4 = VALUE #(
+      ( 7 ) ( 13 ) ( 14 ) ( 3 ) ( 0 ) ( 6 ) ( 9 ) ( 10 )
+      ( 1 ) ( 2 ) ( 8 ) ( 5 ) ( 11 ) ( 12 ) ( 4 ) ( 15 )
+      ( 13 ) ( 8 ) ( 11 ) ( 5 ) ( 6 ) ( 15 ) ( 0 ) ( 3 )
+      ( 4 ) ( 7 ) ( 2 ) ( 12 ) ( 1 ) ( 10 ) ( 14 ) ( 9 )
+      ( 10 ) ( 6 ) ( 9 ) ( 0 ) ( 12 ) ( 11 ) ( 7 ) ( 13 )
+      ( 15 ) ( 1 ) ( 3 ) ( 14 ) ( 5 ) ( 2 ) ( 8 ) ( 4 )
+      ( 3 ) ( 15 ) ( 0 ) ( 6 ) ( 10 ) ( 1 ) ( 13 ) ( 8 )
+      ( 9 ) ( 4 ) ( 5 ) ( 11 ) ( 12 ) ( 7 ) ( 2 ) ( 14 ) ).
+
+    mt_s5 = VALUE #(
+      ( 2 ) ( 12 ) ( 4 ) ( 1 ) ( 7 ) ( 10 ) ( 11 ) ( 6 )
+      ( 8 ) ( 5 ) ( 3 ) ( 15 ) ( 13 ) ( 0 ) ( 14 ) ( 9 )
+      ( 14 ) ( 11 ) ( 2 ) ( 12 ) ( 4 ) ( 7 ) ( 13 ) ( 1 )
+      ( 5 ) ( 0 ) ( 15 ) ( 10 ) ( 3 ) ( 9 ) ( 8 ) ( 6 )
+      ( 4 ) ( 2 ) ( 1 ) ( 11 ) ( 10 ) ( 13 ) ( 7 ) ( 8 )
+      ( 15 ) ( 9 ) ( 12 ) ( 5 ) ( 6 ) ( 3 ) ( 0 ) ( 14 )
+      ( 11 ) ( 8 ) ( 12 ) ( 7 ) ( 1 ) ( 14 ) ( 2 ) ( 13 )
+      ( 6 ) ( 15 ) ( 0 ) ( 9 ) ( 10 ) ( 4 ) ( 5 ) ( 3 ) ).
+
+    mt_s6 = VALUE #(
+      ( 12 ) ( 1 ) ( 10 ) ( 15 ) ( 9 ) ( 2 ) ( 6 ) ( 8 )
+      ( 0 ) ( 13 ) ( 3 ) ( 4 ) ( 14 ) ( 7 ) ( 5 ) ( 11 )
+      ( 10 ) ( 15 ) ( 4 ) ( 2 ) ( 7 ) ( 12 ) ( 9 ) ( 5 )
+      ( 6 ) ( 1 ) ( 13 ) ( 14 ) ( 0 ) ( 11 ) ( 3 ) ( 8 )
+      ( 9 ) ( 14 ) ( 15 ) ( 5 ) ( 2 ) ( 8 ) ( 12 ) ( 3 )
+      ( 7 ) ( 0 ) ( 4 ) ( 10 ) ( 1 ) ( 13 ) ( 11 ) ( 6 )
+      ( 4 ) ( 3 ) ( 2 ) ( 12 ) ( 9 ) ( 5 ) ( 15 ) ( 10 )
+      ( 11 ) ( 14 ) ( 1 ) ( 7 ) ( 6 ) ( 0 ) ( 8 ) ( 13 ) ).
+
+    mt_s7 = VALUE #(
+      ( 4 ) ( 11 ) ( 2 ) ( 14 ) ( 15 ) ( 0 ) ( 8 ) ( 13 )
+      ( 3 ) ( 12 ) ( 9 ) ( 7 ) ( 5 ) ( 10 ) ( 6 ) ( 1 )
+      ( 13 ) ( 0 ) ( 11 ) ( 7 ) ( 4 ) ( 9 ) ( 1 ) ( 10 )
+      ( 14 ) ( 3 ) ( 5 ) ( 12 ) ( 2 ) ( 15 ) ( 8 ) ( 6 )
+      ( 1 ) ( 4 ) ( 11 ) ( 13 ) ( 12 ) ( 3 ) ( 7 ) ( 14 )
+      ( 10 ) ( 15 ) ( 6 ) ( 8 ) ( 0 ) ( 5 ) ( 9 ) ( 2 )
+      ( 6 ) ( 11 ) ( 13 ) ( 8 ) ( 1 ) ( 4 ) ( 10 ) ( 7 )
+      ( 9 ) ( 5 ) ( 0 ) ( 15 ) ( 14 ) ( 2 ) ( 3 ) ( 12 ) ).
+
+    mt_s8 = VALUE #(
+      ( 13 ) ( 2 ) ( 8 ) ( 4 ) ( 6 ) ( 15 ) ( 11 ) ( 1 )
+      ( 10 ) ( 9 ) ( 3 ) ( 14 ) ( 5 ) ( 0 ) ( 12 ) ( 7 )
+      ( 1 ) ( 15 ) ( 13 ) ( 8 ) ( 10 ) ( 3 ) ( 7 ) ( 4 )
+      ( 12 ) ( 5 ) ( 6 ) ( 11 ) ( 0 ) ( 14 ) ( 9 ) ( 2 )
+      ( 7 ) ( 11 ) ( 4 ) ( 1 ) ( 9 ) ( 12 ) ( 14 ) ( 2 )
+      ( 0 ) ( 6 ) ( 10 ) ( 13 ) ( 15 ) ( 3 ) ( 5 ) ( 8 )
+      ( 2 ) ( 1 ) ( 14 ) ( 7 ) ( 4 ) ( 10 ) ( 8 ) ( 13 )
+      ( 15 ) ( 12 ) ( 9 ) ( 0 ) ( 3 ) ( 5 ) ( 6 ) ( 11 ) ).
+
+  ENDMETHOD.
+
+
   METHOD column.
 
-    CASE iv_b+1(4).
-      WHEN '0000'.
-        rv_column = 0.
-      WHEN '0001'.
-        rv_column = 1.
-      WHEN '0010'.
-        rv_column = 2.
-      WHEN '0011'.
-        rv_column = 3.
-      WHEN '0100'.
-        rv_column = 4.
-      WHEN '0101'.
-        rv_column = 5.
-      WHEN '0110'.
-        rv_column = 6.
-      WHEN '0111'.
-        rv_column = 7.
-      WHEN '1000'.
-        rv_column = 8.
-      WHEN '1001'.
-        rv_column = 9.
-      WHEN '1010'.
-        rv_column = 10.
-      WHEN '1011'.
-        rv_column = 11.
-      WHEN '1100'.
-        rv_column = 12.
-      WHEN '1101'.
-        rv_column = 13.
-      WHEN '1110'.
-        rv_column = 14.
-      WHEN '1111'.
-        rv_column = 15.
-      WHEN OTHERS.
-        ASSERT 1 = 1 + 1.
-    ENDCASE.
+    rv_column = 8 * iv_b+1(1) + 4 * iv_b+2(1) + 2 * iv_b+3(1) + iv_b+4(1).
+
+    ASSERT rv_column >= 0.
+    ASSERT rv_column <= 15.
 
   ENDMETHOD.
 
 
   METHOD c_and_d.
 
-    DATA: lv_c_n TYPE c LENGTH 28,
-          lv_d_n TYPE c LENGTH 28,
-          lv_str TYPE string.
-
-    DEFINE _shift.
-      SHIFT lv_c_n LEFT BY &1 PLACES CIRCULAR.
-      SHIFT lv_d_n LEFT BY &1 PLACES CIRCULAR.
-      CONCATENATE lv_c_n lv_d_n INTO lv_str.
-      APPEND lv_str TO rt_bits.
-    END-OF-DEFINITION.
-
+    DATA: lv_shift TYPE i,
+          lv_c_n   TYPE c LENGTH 28,
+          lv_d_n   TYPE c LENGTH 28,
+          lv_str   TYPE string.
 
     lv_c_n = iv_c_0.
     lv_d_n = iv_d_0.
 
-    _shift 1.
-    _shift 1.
-    _shift 2.
-    _shift 2.
-    _shift 2.
-    _shift 2.
-    _shift 2.
-    _shift 2.
-    _shift 1.
-    _shift 2.
-    _shift 2.
-    _shift 2.
-    _shift 2.
-    _shift 2.
-    _shift 2.
-    _shift 1.
+    LOOP AT VALUE tty_itab(
+        ( 1 ) ( 1 ) ( 2 ) ( 2 ) ( 2 ) ( 2 ) ( 2 ) ( 2 )
+        ( 1 ) ( 2 ) ( 2 ) ( 2 ) ( 2 ) ( 2 ) ( 2 ) ( 1 ) ) INTO lv_shift.
+
+      SHIFT lv_c_n LEFT BY lv_shift PLACES CIRCULAR.
+      SHIFT lv_d_n LEFT BY lv_shift PLACES CIRCULAR.
+      CONCATENATE lv_c_n lv_d_n INTO lv_str.
+      APPEND lv_str TO rt_bits.
+
+    ENDLOOP.
 
   ENDMETHOD.
 
@@ -383,43 +500,11 @@ CLASS ZCL_DES IMPLEMENTATION.
 
 
   METHOD i_to_bits_4.
+    CONSTANTS lc_bits TYPE string VALUE '0000000100100011010001010110011110001001101010111100110111101111'.
+    DATA lv_index TYPE i.
 
-    CASE iv_i.
-      WHEN 0.
-        rv_bits = '0000'.
-      WHEN 1.
-        rv_bits = '0001'.
-      WHEN 2.
-        rv_bits = '0010'.
-      WHEN 3.
-        rv_bits = '0011'.
-      WHEN 4.
-        rv_bits = '0100'.
-      WHEN 5.
-        rv_bits = '0101'.
-      WHEN 6.
-        rv_bits = '0110'.
-      WHEN 7.
-        rv_bits = '0111'.
-      WHEN 8.
-        rv_bits = '1000'.
-      WHEN 9.
-        rv_bits = '1001'.
-      WHEN 10.
-        rv_bits = '1010'.
-      WHEN 11.
-        rv_bits = '1011'.
-      WHEN 12.
-        rv_bits = '1100'.
-      WHEN 13.
-        rv_bits = '1101'.
-      WHEN 14.
-        rv_bits = '1110'.
-      WHEN 15.
-        rv_bits = '1111'.
-      WHEN OTHERS.
-        ASSERT 1 = 1 + 1.
-    ENDCASE.
+    lv_index = iv_i * 4.
+    rv_bits = lc_bits+lv_index(4).
 
   ENDMETHOD.
 
@@ -503,498 +588,66 @@ CLASS ZCL_DES IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD permute_e.
+  METHOD permute.
+    DATA: lv_offset  TYPE i.
 
-    DATA: lv_offset TYPE i.
+    LOOP AT it_permutation INTO lv_offset.
 
-    DEFINE _bit.
-      lv_offset = &1 - 1.
+      lv_offset = lv_offset - 1.
       CONCATENATE rv_bits iv_bits+lv_offset(1) INTO rv_bits.
-    END-OF-DEFINITION.
+
+    ENDLOOP.
+
+  ENDMETHOD.
 
 
-    _bit 32.
-    _bit 1.
-    _bit 2.
-    _bit 3.
-    _bit 4.
-    _bit 5.
-    _bit 4.
-    _bit 5.
-    _bit 6.
-    _bit 7.
-    _bit 8.
-    _bit 9.
-    _bit 8.
-    _bit 9.
-    _bit 10.
-    _bit 11.
-    _bit 12.
-    _bit 13.
-    _bit 12.
-    _bit 13.
-    _bit 14.
-    _bit 15.
-    _bit 16.
-    _bit 17.
-    _bit 16.
-    _bit 17.
-    _bit 18.
-    _bit 19.
-    _bit 20.
-    _bit 21.
-    _bit 20.
-    _bit 21.
-    _bit 22.
-    _bit 23.
-    _bit 24.
-    _bit 25.
-    _bit 24.
-    _bit 25.
-    _bit 26.
-    _bit 27.
-    _bit 28.
-    _bit 29.
-    _bit 28.
-    _bit 29.
-    _bit 30.
-    _bit 31.
-    _bit 32.
-    _bit 1.
-
+  METHOD permute_e.
+    rv_bits = permute( it_permutation = mt_e iv_bits = iv_bits ).
   ENDMETHOD.
 
 
   METHOD permute_ip.
-
-    DATA: lv_offset TYPE i.
-
-    DEFINE _bit.
-      lv_offset = &1 - 1.
-      CONCATENATE rv_bits iv_bits+lv_offset(1) INTO rv_bits.
-    END-OF-DEFINITION.
-
-
-    _bit 58.
-    _bit 50.
-    _bit 42.
-    _bit 34.
-    _bit 26.
-    _bit 18.
-    _bit 10.
-    _bit 2.
-    _bit 60.
-    _bit 52.
-    _bit 44.
-    _bit 36.
-    _bit 28.
-    _bit 20.
-    _bit 12.
-    _bit 4.
-    _bit 62.
-    _bit 54.
-    _bit 46.
-    _bit 38.
-    _bit 30.
-    _bit 22.
-    _bit 14.
-    _bit 6.
-    _bit 64.
-    _bit 56.
-    _bit 48.
-    _bit 40.
-    _bit 32.
-    _bit 24.
-    _bit 16.
-    _bit 8.
-    _bit 57.
-    _bit 49.
-    _bit 41.
-    _bit 33.
-    _bit 25.
-    _bit 17.
-    _bit 9.
-    _bit 1.
-    _bit 59.
-    _bit 51.
-    _bit 43.
-    _bit 35.
-    _bit 27.
-    _bit 19.
-    _bit 11.
-    _bit 3.
-    _bit 61.
-    _bit 53.
-    _bit 45.
-    _bit 37.
-    _bit 29.
-    _bit 21.
-    _bit 13.
-    _bit 5.
-    _bit 63.
-    _bit 55.
-    _bit 47.
-    _bit 39.
-    _bit 31.
-    _bit 23.
-    _bit 15.
-    _bit 7.
-
+    rv_bits = permute( it_permutation = mt_ip iv_bits = iv_bits ).
   ENDMETHOD.
 
 
   METHOD permute_ip1.
-
-    DATA: lv_offset TYPE i.
-
-    DEFINE _bit.
-      lv_offset = &1 - 1.
-      CONCATENATE rv_bits iv_bits+lv_offset(1) INTO rv_bits.
-    END-OF-DEFINITION.
-
-
-    _bit 40.
-    _bit 8.
-    _bit 48.
-    _bit 16.
-    _bit 56.
-    _bit 24.
-    _bit 64.
-    _bit 32.
-    _bit 39.
-    _bit 7.
-    _bit 47.
-    _bit 15.
-    _bit 55.
-    _bit 23.
-    _bit 63.
-    _bit 31.
-    _bit 38.
-    _bit 6.
-    _bit 46.
-    _bit 14.
-    _bit 54.
-    _bit 22.
-    _bit 62.
-    _bit 30.
-    _bit 37.
-    _bit 5.
-    _bit 45.
-    _bit 13.
-    _bit 53.
-    _bit 21.
-    _bit 61.
-    _bit 29.
-    _bit 36.
-    _bit 4.
-    _bit 44.
-    _bit 12.
-    _bit 52.
-    _bit 20.
-    _bit 60.
-    _bit 28.
-    _bit 35.
-    _bit 3.
-    _bit 43.
-    _bit 11.
-    _bit 51.
-    _bit 19.
-    _bit 59.
-    _bit 27.
-    _bit 34.
-    _bit 2.
-    _bit 42.
-    _bit 10.
-    _bit 50.
-    _bit 18.
-    _bit 58.
-    _bit 26.
-    _bit 33.
-    _bit 1.
-    _bit 41.
-    _bit 9.
-    _bit 49.
-    _bit 17.
-    _bit 57.
-    _bit 25.
-
+    rv_bits = permute( it_permutation = mt_ip1 iv_bits = iv_bits ).
   ENDMETHOD.
 
 
   METHOD permute_p.
-
-    DATA: lv_offset TYPE i.
-
-    DEFINE _bit.
-      lv_offset = &1 - 1.
-      CONCATENATE rv_bits iv_bits+lv_offset(1) INTO rv_bits.
-    END-OF-DEFINITION.
-
-
-    _bit 16.
-    _bit 7.
-    _bit 20.
-    _bit 21.
-    _bit 29.
-    _bit 12.
-    _bit 28.
-    _bit 17.
-    _bit 1.
-    _bit 15.
-    _bit 23.
-    _bit 26.
-    _bit 5.
-    _bit 18.
-    _bit 31.
-    _bit 10.
-    _bit 2.
-    _bit 8.
-    _bit 24.
-    _bit 14.
-    _bit 32.
-    _bit 27.
-    _bit 3.
-    _bit 9.
-    _bit 19.
-    _bit 13.
-    _bit 30.
-    _bit 6.
-    _bit 22.
-    _bit 11.
-    _bit 4.
-    _bit 25.
-
+    rv_bits = permute( it_permutation = mt_p iv_bits = iv_bits ).
   ENDMETHOD.
 
 
   METHOD permute_pc1.
-
-    DATA: lv_offset TYPE i.
-
-    DEFINE _bit.
-      lv_offset = &1 - 1.
-      CONCATENATE rv_bits iv_bits+lv_offset(1) INTO rv_bits.
-    END-OF-DEFINITION.
-
-
-    _bit 57.
-    _bit 49.
-    _bit 41.
-    _bit 33.
-    _bit 25.
-    _bit 17.
-    _bit 9.
-    _bit 1.
-    _bit 58.
-    _bit 50.
-    _bit 42.
-    _bit 34.
-    _bit 26.
-    _bit 18.
-    _bit 10.
-    _bit 2.
-    _bit 59.
-    _bit 51.
-    _bit 43.
-    _bit 35.
-    _bit 27.
-    _bit 19.
-    _bit 11.
-    _bit 3.
-    _bit 60.
-    _bit 52.
-    _bit 44.
-    _bit 36.
-    _bit 63.
-    _bit 55.
-    _bit 47.
-    _bit 39.
-    _bit 31.
-    _bit 23.
-    _bit 15.
-    _bit 7.
-    _bit 62.
-    _bit 54.
-    _bit 46.
-    _bit 38.
-    _bit 30.
-    _bit 22.
-    _bit 14.
-    _bit 6.
-    _bit 61.
-    _bit 53.
-    _bit 45.
-    _bit 37.
-    _bit 29.
-    _bit 21.
-    _bit 13.
-    _bit 5.
-    _bit 28.
-    _bit 20.
-    _bit 12.
-    _bit 4.
-
+    rv_bits = permute( it_permutation = mt_pc1 iv_bits = iv_bits ).
   ENDMETHOD.
 
 
   METHOD permute_pc2.
-
-    DATA: lv_offset TYPE i.
-
-    DEFINE _bit.
-      lv_offset = &1 - 1.
-      CONCATENATE rv_bits iv_bits+lv_offset(1) INTO rv_bits.
-    END-OF-DEFINITION.
-
-
-    _bit 14.
-    _bit 17.
-    _bit 11.
-    _bit 24.
-    _bit 1.
-    _bit 5.
-    _bit 3.
-    _bit 28.
-    _bit 15.
-    _bit 6.
-    _bit 21.
-    _bit 10.
-    _bit 23.
-    _bit 19.
-    _bit 12.
-    _bit 4.
-    _bit 26.
-    _bit 8.
-    _bit 16.
-    _bit 7.
-    _bit 27.
-    _bit 20.
-    _bit 13.
-    _bit 2.
-    _bit 41.
-    _bit 52.
-    _bit 31.
-    _bit 37.
-    _bit 47.
-    _bit 55.
-    _bit 30.
-    _bit 40.
-    _bit 51.
-    _bit 45.
-    _bit 33.
-    _bit 48.
-    _bit 44.
-    _bit 49.
-    _bit 39.
-    _bit 56.
-    _bit 34.
-    _bit 53.
-    _bit 46.
-    _bit 42.
-    _bit 50.
-    _bit 36.
-    _bit 29.
-    _bit 32.
-
+    rv_bits = permute( it_permutation = mt_pc2 iv_bits = iv_bits ).
   ENDMETHOD.
 
 
   METHOD row.
 
-    DATA: lv_c TYPE c LENGTH 2.
+    rv_row = 2 * iv_b(1) + iv_b+5(1).
 
-
-    CONCATENATE iv_b(1) iv_b+5(1) INTO lv_c.
-    CASE lv_c.
-      WHEN '00'.
-        rv_row = 0.
-      WHEN '01'.
-        rv_row = 1.
-      WHEN '10'.
-        rv_row = 2.
-      WHEN '11'.
-        rv_row = 3.
-      WHEN OTHERS.
-        ASSERT 1 = 1 + 1.
-    ENDCASE.
+    ASSERT rv_row >= 0.
+    ASSERT rv_row <= 3.
 
   ENDMETHOD.
 
 
   METHOD s1.
 
-    DATA: lt_table TYPE TABLE OF i,
-          lv_index TYPE i,
+    DATA: lv_index TYPE i,
           lv_i     TYPE i.
 
-
-    APPEND 14 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 13 TO lt_table.
-
     lv_index = ( row( iv_b ) * 16 ) + column( iv_b ) + 1.
-    READ TABLE lt_table INDEX lv_index INTO lv_i.
+    READ TABLE mt_s1 INDEX lv_index INTO lv_i.
     ASSERT sy-subrc = 0.
     rv_s = i_to_bits_4( lv_i ).
 
@@ -1003,78 +656,11 @@ CLASS ZCL_DES IMPLEMENTATION.
 
   METHOD s2.
 
-    DATA: lt_table TYPE TABLE OF i,
-          lv_index TYPE i,
+    DATA: lv_index TYPE i,
           lv_i     TYPE i.
 
-
-    APPEND 15 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 9  TO lt_table.
-
     lv_index = ( row( iv_b ) * 16 ) + column( iv_b ) + 1.
-    READ TABLE lt_table INDEX lv_index INTO lv_i.
+    READ TABLE mt_s2 INDEX lv_index INTO lv_i.
     ASSERT sy-subrc = 0.
     rv_s = i_to_bits_4( lv_i ).
 
@@ -1083,78 +669,11 @@ CLASS ZCL_DES IMPLEMENTATION.
 
   METHOD s3.
 
-    DATA: lt_table TYPE TABLE OF i,
-          lv_index TYPE i,
+    DATA: lv_index TYPE i,
           lv_i     TYPE i.
 
-
-    APPEND 10 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 12 TO lt_table.
-
     lv_index = ( row( iv_b ) * 16 ) + column( iv_b ) + 1.
-    READ TABLE lt_table INDEX lv_index INTO lv_i.
+    READ TABLE mt_s3 INDEX lv_index INTO lv_i.
     ASSERT sy-subrc = 0.
     rv_s = i_to_bits_4( lv_i ).
 
@@ -1163,78 +682,11 @@ CLASS ZCL_DES IMPLEMENTATION.
 
   METHOD s4.
 
-    DATA: lt_table TYPE TABLE OF i,
-          lv_index TYPE i,
+    DATA: lv_index TYPE i,
           lv_i     TYPE i.
 
-
-    APPEND 7  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 14 TO lt_table.
-
     lv_index = ( row( iv_b ) * 16 ) + column( iv_b ) + 1.
-    READ TABLE lt_table INDEX lv_index INTO lv_i.
+    READ TABLE mt_s4 INDEX lv_index INTO lv_i.
     ASSERT sy-subrc = 0.
     rv_s = i_to_bits_4( lv_i ).
 
@@ -1243,78 +695,11 @@ CLASS ZCL_DES IMPLEMENTATION.
 
   METHOD s5.
 
-    DATA: lt_table TYPE TABLE OF i,
-          lv_index TYPE i,
+    DATA: lv_index TYPE i,
           lv_i     TYPE i.
 
-
-    APPEND 2  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 3  TO lt_table.
-
     lv_index = ( row( iv_b ) * 16 ) + column( iv_b ) + 1.
-    READ TABLE lt_table INDEX lv_index INTO lv_i.
+    READ TABLE mt_s5 INDEX lv_index INTO lv_i.
     ASSERT sy-subrc = 0.
     rv_s = i_to_bits_4( lv_i ).
 
@@ -1323,78 +708,11 @@ CLASS ZCL_DES IMPLEMENTATION.
 
   METHOD s6.
 
-    DATA: lt_table TYPE TABLE OF i,
-          lv_index TYPE i,
+    DATA: lv_index TYPE i,
           lv_i     TYPE i.
 
-
-    APPEND 12 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 13 TO lt_table.
-
     lv_index = ( row( iv_b ) * 16 ) + column( iv_b ) + 1.
-    READ TABLE lt_table INDEX lv_index INTO lv_i.
+    READ TABLE mt_s6 INDEX lv_index INTO lv_i.
     ASSERT sy-subrc = 0.
     rv_s = i_to_bits_4( lv_i ).
 
@@ -1403,78 +721,11 @@ CLASS ZCL_DES IMPLEMENTATION.
 
   METHOD s7.
 
-    DATA: lt_table TYPE TABLE OF i,
-          lv_index TYPE i,
+    DATA: lv_index TYPE i,
           lv_i     TYPE i.
 
-
-    APPEND 4  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 12 TO lt_table.
-
     lv_index = ( row( iv_b ) * 16 ) + column( iv_b ) + 1.
-    READ TABLE lt_table INDEX lv_index INTO lv_i.
+    READ TABLE mt_s7 INDEX lv_index INTO lv_i.
     ASSERT sy-subrc = 0.
     rv_s = i_to_bits_4( lv_i ).
 
@@ -1483,78 +734,11 @@ CLASS ZCL_DES IMPLEMENTATION.
 
   METHOD s8.
 
-    DATA: lt_table TYPE TABLE OF i,
-          lv_index TYPE i,
+    DATA: lv_index TYPE i,
           lv_i     TYPE i.
 
-
-    APPEND 13 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 11 TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 2  TO lt_table.
-    APPEND 1  TO lt_table.
-    APPEND 14 TO lt_table.
-    APPEND 7  TO lt_table.
-    APPEND 4  TO lt_table.
-    APPEND 10 TO lt_table.
-    APPEND 8  TO lt_table.
-    APPEND 13 TO lt_table.
-    APPEND 15 TO lt_table.
-    APPEND 12 TO lt_table.
-    APPEND 9  TO lt_table.
-    APPEND 0  TO lt_table.
-    APPEND 3  TO lt_table.
-    APPEND 5  TO lt_table.
-    APPEND 6  TO lt_table.
-    APPEND 11 TO lt_table.
-
     lv_index = ( row( iv_b ) * 16 ) + column( iv_b ) + 1.
-    READ TABLE lt_table INDEX lv_index INTO lv_i.
+    READ TABLE mt_s8 INDEX lv_index INTO lv_i.
     ASSERT sy-subrc = 0.
     rv_s = i_to_bits_4( lv_i ).
 

--- a/src/zcl_md4.clas.abap
+++ b/src/zcl_md4.clas.abap
@@ -3,16 +3,14 @@ CLASS zcl_md4 DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
-*"* public components of class ZCL_MD4
-*"* do not include other source files here!!!
 
     TYPES:
+*"* public components of class ZCL_MD4
+*"* do not include other source files here!!!
       ty_byte4 TYPE x LENGTH 4 .
     TYPES:
       ty_byte16 TYPE x LENGTH 16 .
 
-    TYPE-POOLS abap .
-    CLASS zcl_md4 DEFINITION LOAD .
     CLASS-METHODS hash
       IMPORTING
         !iv_string     TYPE clike
@@ -25,84 +23,7 @@ CLASS zcl_md4 DEFINITION
       RETURNING
         VALUE(rv_hash) TYPE ty_byte16 .
   PROTECTED SECTION.
-*"* protected components of class ZCL_MD4
-*"* do not include other source files here!!!
 
-    CLASS-METHODS overflow
-      IMPORTING
-        !iv_f         TYPE f
-      RETURNING
-        VALUE(rv_res) TYPE ty_byte4 .
-    CLASS-METHODS shift
-      IMPORTING
-        !iv_input        TYPE ty_byte4
-        !iv_places       TYPE i
-      RETURNING
-        VALUE(rv_output) TYPE ty_byte4 .
-    CLASS-METHODS x
-      IMPORTING
-        !iv_xstr       TYPE xstring
-        !iv_block      TYPE i
-        !iv_word       TYPE i
-      RETURNING
-        VALUE(rv_word) TYPE ty_byte4 .
-    CLASS-METHODS func_f
-      IMPORTING
-        !iv_x         TYPE ty_byte4
-        !iv_y         TYPE ty_byte4
-        !iv_z         TYPE ty_byte4
-      RETURNING
-        VALUE(rv_res) TYPE ty_byte4 .
-    CLASS-METHODS func_ff
-      IMPORTING
-        !iv_a         TYPE ty_byte4
-        !iv_b         TYPE ty_byte4
-        !iv_c         TYPE ty_byte4
-        !iv_d         TYPE ty_byte4
-        !iv_x         TYPE ty_byte4
-        !iv_s         TYPE i
-      RETURNING
-        VALUE(rv_res) TYPE ty_byte4 .
-    CLASS-METHODS func_gg
-      IMPORTING
-        !iv_a         TYPE ty_byte4
-        !iv_b         TYPE ty_byte4
-        !iv_c         TYPE ty_byte4
-        !iv_d         TYPE ty_byte4
-        !iv_x         TYPE ty_byte4
-        !iv_s         TYPE i
-      RETURNING
-        VALUE(rv_res) TYPE ty_byte4 .
-    CLASS-METHODS func_hh
-      IMPORTING
-        !iv_a         TYPE ty_byte4
-        !iv_b         TYPE ty_byte4
-        !iv_c         TYPE ty_byte4
-        !iv_d         TYPE ty_byte4
-        !iv_x         TYPE ty_byte4
-        !iv_s         TYPE i
-      RETURNING
-        VALUE(rv_res) TYPE ty_byte4 .
-    CLASS-METHODS func_g
-      IMPORTING
-        !iv_x         TYPE ty_byte4
-        !iv_y         TYPE ty_byte4
-        !iv_z         TYPE ty_byte4
-      RETURNING
-        VALUE(rv_res) TYPE ty_byte4 .
-    CLASS-METHODS func_h
-      IMPORTING
-        !iv_x         TYPE ty_byte4
-        !iv_y         TYPE ty_byte4
-        !iv_z         TYPE ty_byte4
-      RETURNING
-        VALUE(rv_res) TYPE ty_byte4 .
-    CLASS-METHODS padding_length
-      IMPORTING
-        !iv_input         TYPE xstring
-      RETURNING
-        VALUE(rv_xstring) TYPE xstring .
-    TYPE-POOLS abap .
     CLASS-METHODS codepage
       IMPORTING
         !iv_encoding      TYPE abap_encoding DEFAULT 'UTF-8'
@@ -130,93 +51,6 @@ CLASS ZCL_MD4 IMPLEMENTATION.
                        data = iv_string
                        n = strlen( iv_string )
                      IMPORTING buffer = rv_xstring ).
-
-  ENDMETHOD.
-
-
-  METHOD func_f.
-
-* XY v not(X) Z
-
-    rv_res = ( iv_x BIT-AND iv_y ) BIT-OR ( ( BIT-NOT iv_x ) BIT-AND iv_z ).
-
-  ENDMETHOD.
-
-
-  METHOD func_ff.
-
-    DATA: lv_f TYPE f.
-
-* (a + F(b,c,d) + X[k]) <<< s
-
-    lv_f = iv_a +
-      func_f( iv_x = iv_b
-              iv_y = iv_c
-              iv_z = iv_d ) +
-      iv_x.
-    rv_res = overflow( lv_f ).
-    rv_res = shift( iv_input  = rv_res
-                    iv_places = iv_s ).
-
-  ENDMETHOD.
-
-
-  METHOD func_g.
-
-* XY v XZ v YZ
-
-    rv_res = ( iv_x BIT-AND iv_y )
-      BIT-OR ( iv_x BIT-AND iv_z )
-      BIT-OR ( iv_y BIT-AND iv_z ).
-
-  ENDMETHOD.
-
-
-  METHOD func_gg.
-
-    CONSTANTS: lc_add TYPE x LENGTH 4 VALUE '5A827999'.
-
-    DATA: lv_f TYPE f.
-
-* (a + G(b,c,d) + X[k] + 5A827999) <<< s
-
-    lv_f = iv_a +
-      func_g( iv_x = iv_b
-              iv_y = iv_c
-              iv_z = iv_d ) +
-      iv_x + lc_add.
-    rv_res = overflow( lv_f ).
-    rv_res = shift( iv_input  = rv_res
-                    iv_places = iv_s ).
-
-  ENDMETHOD.
-
-
-  METHOD func_h.
-
-* X xor Y xor Z
-
-    rv_res = ( iv_x BIT-XOR iv_y ) BIT-XOR iv_z.
-
-  ENDMETHOD.
-
-
-  METHOD func_hh.
-
-    CONSTANTS: lc_add TYPE x LENGTH 4 VALUE '6ED9EBA1'.
-
-    DATA: lv_f TYPE f.
-
-* (a + H(b,c,d) + X[k] + 6ED9EBA1) <<< s
-
-    lv_f = iv_a +
-      func_h( iv_x = iv_b
-              iv_y = iv_c
-              iv_z = iv_d ) +
-      iv_x + lc_add.
-    rv_res = overflow( lv_f ).
-    rv_res = shift( iv_input  = rv_res
-                    iv_places = iv_s ).
 
   ENDMETHOD.
 
@@ -282,228 +116,31 @@ CLASS ZCL_MD4 IMPLEMENTATION.
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 
-    DATA: lv_xstr TYPE xstring.
+    DATA: lo_barrel TYPE REF TO lcl_barrel,
+          lo_buffer TYPE REF TO lcl_buffer,
+          lo_ff     TYPE REF TO lcl_ff,
+          lo_gg     TYPE REF TO lcl_gg,
+          lo_hh     TYPE REF TO lcl_hh.
 
-* big endian
-    DATA: lv_a TYPE x LENGTH 4 VALUE '67452301',
-          lv_b TYPE x LENGTH 4 VALUE 'EFCDAB89',
-          lv_c TYPE x LENGTH 4 VALUE '98BADCFE',
-          lv_d TYPE x LENGTH 4 VALUE '10325476'.
-
-    DATA: lv_aa TYPE x LENGTH 4,
-          lv_bb TYPE x LENGTH 4,
-          lv_cc TYPE x LENGTH 4,
-          lv_dd TYPE x LENGTH 4.
-
-    DATA: lv_x     TYPE ty_byte4,
-          lv_f     TYPE f,
-          lv_block TYPE i.
-
-    DEFINE _ff.
-      lv_x = x(
-          iv_xstr  = lv_xstr
-          iv_block = lv_block
-          iv_word  = &5 ).
-      &1 = func_ff(
-        iv_a   = &1
-        iv_b   = &2
-        iv_c   = &3
-        iv_d   = &4
-        iv_x   = lv_x
-        iv_s   = &6 ).
-    END-OF-DEFINITION.
-
-    DEFINE _gg.
-      lv_x = x(
-          iv_xstr  = lv_xstr
-          iv_block = lv_block
-          iv_word  = &5 ).
-      &1 = func_gg(
-        iv_a   = &1
-        iv_b   = &2
-        iv_c   = &3
-        iv_d   = &4
-        iv_x   = lv_x
-        iv_s   = &6 ).
-    END-OF-DEFINITION.
-
-    DEFINE _hh.
-      lv_x = x(
-          iv_xstr  = lv_xstr
-          iv_block = lv_block
-          iv_word  = &5 ).
-      &1 = func_hh(
-        iv_a   = &1
-        iv_b   = &2
-        iv_c   = &3
-        iv_d   = &4
-        iv_x   = lv_x
-        iv_s   = &6 ).
-    END-OF-DEFINITION.
-
-
-    lv_xstr = padding_length( iv_xstr ).
+    lo_buffer = NEW #( iv_xstr ).
+    lo_barrel = NEW #( ).
+    lo_ff = NEW #( io_barrel = lo_barrel io_buffer = lo_buffer ).
+    lo_gg = NEW #( io_barrel = lo_barrel io_buffer = lo_buffer ).
+    lo_hh = NEW #( io_barrel = lo_barrel io_buffer = lo_buffer ).
 
 * 16 words = 64 byte
-    DO xstrlen( lv_xstr ) / 64 TIMES.
-      lv_block = sy-index.
+    DO lo_buffer->get_blocks( ) TIMES.
+      lo_buffer->set_block( sy-index ).
+      lo_barrel->snapshot( ).
 
-      lv_aa = lv_a.
-      lv_bb = lv_b.
-      lv_cc = lv_c.
-      lv_dd = lv_d.
+      lo_ff->hash( ).
+      lo_gg->hash( ).
+      lo_hh->hash( ).
 
-* round 1
-      _ff lv_a lv_b lv_c lv_d  0  3.
-      _ff lv_d lv_a lv_b lv_c  1  7.
-      _ff lv_c lv_d lv_a lv_b  2 11.
-      _ff lv_b lv_c lv_d lv_a  3 19.
-      _ff lv_a lv_b lv_c lv_d  4  3.
-      _ff lv_d lv_a lv_b lv_c  5  7.
-      _ff lv_c lv_d lv_a lv_b  6 11.
-      _ff lv_b lv_c lv_d lv_a  7 19.
-      _ff lv_a lv_b lv_c lv_d  8  3.
-      _ff lv_d lv_a lv_b lv_c  9  7.
-      _ff lv_c lv_d lv_a lv_b 10 11.
-      _ff lv_b lv_c lv_d lv_a 11 19.
-      _ff lv_a lv_b lv_c lv_d 12  3.
-      _ff lv_d lv_a lv_b lv_c 13  7.
-      _ff lv_c lv_d lv_a lv_b 14 11.
-      _ff lv_b lv_c lv_d lv_a 15 19.
-
-* round 2
-      _gg lv_a lv_b lv_c lv_d  0  3.
-      _gg lv_d lv_a lv_b lv_c  4  5.
-      _gg lv_c lv_d lv_a lv_b  8  9.
-      _gg lv_b lv_c lv_d lv_a 12 13.
-      _gg lv_a lv_b lv_c lv_d  1  3.
-      _gg lv_d lv_a lv_b lv_c  5  5.
-      _gg lv_c lv_d lv_a lv_b  9  9.
-      _gg lv_b lv_c lv_d lv_a 13 13.
-      _gg lv_a lv_b lv_c lv_d  2  3.
-      _gg lv_d lv_a lv_b lv_c  6  5.
-      _gg lv_c lv_d lv_a lv_b 10  9.
-      _gg lv_b lv_c lv_d lv_a 14 13.
-      _gg lv_a lv_b lv_c lv_d  3  3.
-      _gg lv_d lv_a lv_b lv_c  7  5.
-      _gg lv_c lv_d lv_a lv_b 11  9.
-      _gg lv_b lv_c lv_d lv_a 15 13.
-
-* round 3
-      _hh lv_a lv_b lv_c lv_d  0  3.
-      _hh lv_d lv_a lv_b lv_c  8  9.
-      _hh lv_c lv_d lv_a lv_b  4 11.
-      _hh lv_b lv_c lv_d lv_a 12 15.
-      _hh lv_a lv_b lv_c lv_d  2  3.
-      _hh lv_d lv_a lv_b lv_c 10  9.
-      _hh lv_c lv_d lv_a lv_b  6 11.
-      _hh lv_b lv_c lv_d lv_a 14 15.
-      _hh lv_a lv_b lv_c lv_d  1  3.
-      _hh lv_d lv_a lv_b lv_c  9  9.
-      _hh lv_c lv_d lv_a lv_b  5 11.
-      _hh lv_b lv_c lv_d lv_a 13 15.
-      _hh lv_a lv_b lv_c lv_d  3  3.
-      _hh lv_d lv_a lv_b lv_c 11  9.
-      _hh lv_c lv_d lv_a lv_b  7 11.
-      _hh lv_b lv_c lv_d lv_a 15 15.
-
-      lv_f = lv_a + lv_aa.
-      lv_a = overflow( lv_f ).
-      lv_f = lv_b + lv_bb.
-      lv_b = overflow( lv_f ).
-      lv_f = lv_c + lv_cc.
-      lv_c = overflow( lv_f ).
-      lv_f = lv_d + lv_dd.
-      lv_d = overflow( lv_f ).
+      lo_barrel->accumulate( ).
     ENDDO.
 
-    CONCATENATE
-      lv_a+3(1) lv_a+2(1) lv_a+1(1) lv_a(1)
-      lv_b+3(1) lv_b+2(1) lv_b+1(1) lv_b(1)
-      lv_c+3(1) lv_c+2(1) lv_c+1(1) lv_c(1)
-      lv_d+3(1) lv_d+2(1) lv_d+1(1) lv_d(1)
-      INTO rv_hash IN BYTE MODE.
-
-  ENDMETHOD.
-
-
-  METHOD overflow.
-
-    DATA: lv_f      TYPE f,
-          lv_maxint TYPE i.
-
-
-    lv_maxint = 2 ** 31 - 1.
-
-    lv_f = iv_f.
-    IF iv_f < - lv_maxint OR iv_f > lv_maxint.
-      lv_f = ( iv_f + ( lv_maxint + 1 ) ) MOD ( 2 * ( lv_maxint + 1 ) ) - lv_maxint - 1.
-    ENDIF.
-
-    rv_res = lv_f.
-
-  ENDMETHOD.
-
-
-  METHOD padding_length.
-
-    CONSTANTS: lc_x0 TYPE x LENGTH 1 VALUE '00',
-               lc_x1 TYPE x LENGTH 1 VALUE '80'.
-
-    DATA: lv_length TYPE x LENGTH 8. " double word
-
-
-    CONCATENATE iv_input lc_x1 INTO rv_xstring IN BYTE MODE.
-
-    WHILE xstrlen( rv_xstring ) MOD 64 <> 56.
-      CONCATENATE rv_xstring lc_x0 INTO rv_xstring IN BYTE MODE.
-    ENDWHILE.
-
-    lv_length = xstrlen( iv_input ) * 8. " get number of bits
-    CONCATENATE rv_xstring
-      lv_length+7(1) lv_length+6(1) lv_length+5(1) lv_length+4(1)
-      lv_length+3(1) lv_length+2(1) lv_length+1(1) lv_length(1)
-      INTO rv_xstring IN BYTE MODE.
-
-  ENDMETHOD.
-
-
-  METHOD shift.
-
-    DATA: lv_bits   TYPE c LENGTH 32,
-          lv_offset TYPE i,
-          lv_bit    TYPE c LENGTH 1.
-
-
-    DO 32 TIMES.
-      GET BIT sy-index OF iv_input INTO lv_bit.
-      CONCATENATE lv_bits lv_bit INTO lv_bits.
-    ENDDO.
-
-    SHIFT lv_bits LEFT CIRCULAR BY iv_places PLACES.
-
-    DO 32 TIMES.
-      lv_offset = sy-index - 1.
-      lv_bit = lv_bits+lv_offset(1).
-      SET BIT lv_offset + 1 OF rv_output TO lv_bit.
-    ENDDO.
-
-  ENDMETHOD.
-
-
-  METHOD x.
-
-    DATA: lv_offset TYPE i,
-          lv_x      TYPE x.
-
-
-    lv_offset = ( ( iv_block - 1 ) * 16 + iv_word ) * 4.
-
-    DO 4 TIMES.
-      lv_x = iv_xstr+lv_offset(1).
-      CONCATENATE lv_x rv_word INTO rv_word IN BYTE MODE.
-      lv_offset = lv_offset + 1.
-    ENDDO.
+    rv_hash = lo_barrel->get_hash( ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_md4.clas.locals_imp.abap
+++ b/src/zcl_md4.clas.locals_imp.abap
@@ -1,0 +1,494 @@
+*"* use this source file for the definition and implementation of
+*"* local helper classes, interface definitions and type
+*"* declarations
+
+
+CLASS lcl_bit_flipper DEFINITION.
+
+  PROTECTED SECTION.
+
+    METHODS:
+      overflow
+        IMPORTING
+          iv_f             TYPE f
+        RETURNING
+          VALUE(rv_result) TYPE zcl_md4=>ty_byte4,
+      shift
+        IMPORTING
+          iv_input         TYPE zcl_md4=>ty_byte4
+          iv_places        TYPE i
+        RETURNING
+          VALUE(rv_result) TYPE zcl_md4=>ty_byte4.
+
+ENDCLASS.
+
+
+CLASS lcl_barrel DEFINITION.
+
+  PUBLIC SECTION.
+
+    METHODS:
+      constructor,
+      reset,
+      roll,
+      set IMPORTING iv_word TYPE zcl_md4=>ty_byte4,
+      get
+        IMPORTING iv_index         TYPE i
+        RETURNING VALUE(rv_result) TYPE zcl_md4=>ty_byte4,
+      snapshot,
+      accumulate,
+      get_hash RETURNING VALUE(rv_result) TYPE zcl_md4=>ty_byte16.
+
+  PRIVATE SECTION.
+
+    DATA:
+      mt_barrel     TYPE STANDARD TABLE OF zcl_md4=>ty_byte4,
+      mt_old_barrel TYPE STANDARD TABLE OF zcl_md4=>ty_byte4,
+      mv_index      TYPE i.
+
+    METHODS:
+      overflow
+        IMPORTING
+          iv_f             TYPE f
+        RETURNING
+          VALUE(rv_result) TYPE zcl_md4=>ty_byte4.
+
+ENDCLASS.
+
+
+CLASS lcl_buffer DEFINITION INHERITING FROM lcl_bit_flipper.
+
+  PUBLIC SECTION.
+
+    METHODS:
+      constructor IMPORTING iv_xstr TYPE xstring,
+      set_block IMPORTING iv_block TYPE i,
+      get_word IMPORTING iv_word TYPE i RETURNING VALUE(rv_result) TYPE zcl_md4=>ty_byte4,
+      get_blocks RETURNING VALUE(rv_result) TYPE i.
+
+  PRIVATE SECTION.
+
+    DATA:
+      mv_buffer TYPE xstring,
+      mv_block  TYPE i.
+
+ENDCLASS.
+
+
+CLASS lcl_hasher DEFINITION ABSTRACT INHERITING FROM lcl_bit_flipper.
+
+  PUBLIC SECTION.
+    TYPES:
+      BEGIN OF ty_hash_def,
+        word  TYPE i,
+        shift TYPE i,
+      END OF ty_hash_def.
+
+    METHODS:
+      constructor
+        IMPORTING
+          io_buffer TYPE REF TO lcl_buffer
+          io_barrel TYPE REF TO lcl_barrel,
+      hash.
+
+
+  PROTECTED SECTION.
+
+    DATA:
+      mo_buffer   TYPE REF TO lcl_buffer,
+      mo_barrel   TYPE REF TO lcl_barrel,
+      mt_hash_def TYPE STANDARD TABLE OF ty_hash_def,
+      mv_add      TYPE x LENGTH 4.
+
+
+    METHODS:
+      hash_function
+        IMPORTING
+          is_def           TYPE ty_hash_def
+        RETURNING
+          VALUE(rv_result) TYPE zcl_md4=>ty_byte4,
+      func ABSTRACT
+        IMPORTING
+          iv_x             TYPE zcl_md4=>ty_byte4
+          iv_y             TYPE zcl_md4=>ty_byte4
+          iv_z             TYPE zcl_md4=>ty_byte4
+        RETURNING
+          VALUE(rv_result) TYPE zcl_md4=>ty_byte4.
+
+ENDCLASS.
+
+
+CLASS lcl_ff DEFINITION INHERITING FROM lcl_hasher.
+
+  PUBLIC SECTION.
+
+    METHODS:
+      constructor
+        IMPORTING
+          io_buffer TYPE REF TO lcl_buffer
+          io_barrel TYPE REF TO lcl_barrel.
+
+  PROTECTED SECTION.
+
+    METHODS:
+      func REDEFINITION.
+
+ENDCLASS.
+
+
+CLASS lcl_gg DEFINITION INHERITING FROM lcl_hasher.
+
+  PUBLIC SECTION.
+
+    METHODS:
+      constructor
+        IMPORTING
+          io_buffer TYPE REF TO lcl_buffer
+          io_barrel TYPE REF TO lcl_barrel.
+
+  PROTECTED SECTION.
+
+    METHODS:
+      func REDEFINITION.
+
+ENDCLASS.
+
+
+CLASS lcl_hh DEFINITION INHERITING FROM lcl_hasher.
+
+  PUBLIC SECTION.
+
+    METHODS:
+      constructor
+        IMPORTING
+          io_buffer TYPE REF TO lcl_buffer
+          io_barrel TYPE REF TO lcl_barrel.
+
+  PROTECTED SECTION.
+
+    METHODS:
+      func REDEFINITION.
+
+ENDCLASS.
+
+
+CLASS lcl_bit_flipper IMPLEMENTATION.
+
+  METHOD overflow.
+    DATA: lv_f      TYPE f,
+          lv_maxint TYPE i.
+
+    lv_maxint = 2 ** 31 - 1.
+
+    lv_f = iv_f.
+    IF iv_f < - lv_maxint OR iv_f > lv_maxint.
+      lv_f = ( iv_f + ( lv_maxint + 1 ) ) MOD ( 2 * ( lv_maxint + 1 ) ) - lv_maxint - 1.
+    ENDIF.
+
+    rv_result = lv_f.
+
+  ENDMETHOD.
+
+
+  METHOD shift.
+
+    DATA: lv_bits   TYPE c LENGTH 32,
+          lv_offset TYPE i,
+          lv_bit    TYPE c LENGTH 1.
+
+
+    DO 32 TIMES.
+      GET BIT sy-index OF iv_input INTO lv_bit.
+      CONCATENATE lv_bits lv_bit INTO lv_bits.
+    ENDDO.
+
+    SHIFT lv_bits LEFT CIRCULAR BY iv_places PLACES.
+
+    DO 32 TIMES.
+      lv_offset = sy-index - 1.
+      lv_bit = lv_bits+lv_offset(1).
+      SET BIT lv_offset + 1 OF rv_result TO lv_bit.
+    ENDDO.
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS lcl_barrel IMPLEMENTATION.
+
+  METHOD constructor.
+* big endian
+    APPEND '67452301' TO mt_barrel.
+    APPEND 'EFCDAB89' TO mt_barrel.
+    APPEND '98BADCFE' TO mt_barrel.
+    APPEND '10325476' TO mt_barrel.
+    mv_index = 0.
+  ENDMETHOD.
+
+  METHOD reset.
+    mv_index = 0.
+  ENDMETHOD.
+
+  METHOD roll.
+    mv_index = ( mv_index + lines( mt_barrel ) - 1 ) MOD lines( mt_barrel ).
+  ENDMETHOD.
+
+  METHOD set.
+    FIELD-SYMBOLS:
+      <lv_word> TYPE zcl_md4=>ty_byte4.
+
+    READ TABLE mt_barrel
+      INDEX mv_index + 1
+      ASSIGNING <lv_word>.
+
+    ASSERT sy-subrc = 0.
+
+    <lv_word> = iv_word.
+  ENDMETHOD.
+
+  METHOD get.
+    DATA:
+      lv_index TYPE i.
+    FIELD-SYMBOLS:
+      <lv_word> TYPE zcl_md4=>ty_byte4.
+
+    lv_index = ( mv_index + iv_index ) MOD lines( mt_barrel ).
+
+    READ TABLE mt_barrel
+      INDEX lv_index + 1
+      ASSIGNING <lv_word>.
+
+    ASSERT sy-subrc = 0.
+
+    rv_result = <lv_word>.
+  ENDMETHOD.
+
+  METHOD snapshot.
+    CLEAR mt_old_barrel.
+    APPEND LINES OF mt_barrel TO mt_old_barrel.
+  ENDMETHOD.
+
+  METHOD accumulate.
+    DATA:
+      lv_f TYPE f.
+
+    reset( ).
+
+    DO lines( mt_barrel ) TIMES.
+      lv_f = mt_barrel[ mv_index + 1 ] + mt_old_barrel[ mv_index + 1 ].
+      set( overflow( lv_f ) ).
+      roll( ).
+    ENDDO.
+
+  ENDMETHOD.
+
+  METHOD overflow.
+    DATA: lv_f      TYPE f,
+          lv_maxint TYPE i.
+
+    lv_maxint = 2 ** 31 - 1.
+
+    lv_f = iv_f.
+    IF iv_f < - lv_maxint OR iv_f > lv_maxint.
+      lv_f = ( iv_f + ( lv_maxint + 1 ) ) MOD ( 2 * ( lv_maxint + 1 ) ) - lv_maxint - 1.
+    ENDIF.
+
+    rv_result = lv_f.
+
+  ENDMETHOD.
+
+  METHOD get_hash.
+    DATA:
+      lv_a TYPE zcl_md4=>ty_byte4,
+      lv_b TYPE zcl_md4=>ty_byte4,
+      lv_c TYPE zcl_md4=>ty_byte4,
+      lv_d TYPE zcl_md4=>ty_byte4.
+
+    reset( ).
+    lv_a = get( 0 ).
+    lv_b = get( 1 ).
+    lv_c = get( 2 ).
+    lv_d = get( 3 ).
+
+    CONCATENATE
+      lv_a+3(1) lv_a+2(1) lv_a+1(1) lv_a(1)
+      lv_b+3(1) lv_b+2(1) lv_b+1(1) lv_b(1)
+      lv_c+3(1) lv_c+2(1) lv_c+1(1) lv_c(1)
+      lv_d+3(1) lv_d+2(1) lv_d+1(1) lv_d(1)
+      INTO rv_result IN BYTE MODE.
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS lcl_buffer IMPLEMENTATION.
+
+  METHOD constructor.
+    CONSTANTS: lc_x0 TYPE x LENGTH 1 VALUE '00',
+               lc_x1 TYPE x LENGTH 1 VALUE '80'.
+
+    DATA: lv_length TYPE x LENGTH 8. " double word
+
+    super->constructor( ).
+
+    mv_buffer = iv_xstr.
+
+    CONCATENATE iv_xstr lc_x1 INTO mv_buffer IN BYTE MODE.
+
+    WHILE xstrlen( mv_buffer ) MOD 64 <> 56.
+      CONCATENATE mv_buffer lc_x0 INTO mv_buffer IN BYTE MODE.
+    ENDWHILE.
+
+    lv_length = xstrlen( iv_xstr ) * 8. " get number of bits
+    CONCATENATE mv_buffer
+      lv_length+7(1) lv_length+6(1) lv_length+5(1) lv_length+4(1)
+      lv_length+3(1) lv_length+2(1) lv_length+1(1) lv_length(1)
+      INTO mv_buffer IN BYTE MODE.
+  ENDMETHOD.
+
+  METHOD set_block.
+    mv_block = iv_block.
+  ENDMETHOD.
+
+  METHOD get_word.
+    DATA:
+      lv_offset TYPE i,
+      lv_x      TYPE x.
+
+    lv_offset = ( ( mv_block - 1 ) * 16 + iv_word ) * 4.
+
+    DO 4 TIMES.
+      lv_x = mv_buffer+lv_offset(1).
+      CONCATENATE lv_x rv_result INTO rv_result IN BYTE MODE.
+      lv_offset = lv_offset + 1.
+    ENDDO.
+
+  ENDMETHOD.
+
+  METHOD get_blocks.
+    rv_result = xstrlen( mv_buffer ) / 64.
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+
+CLASS lcl_hasher IMPLEMENTATION.
+
+  METHOD constructor.
+    super->constructor( ).
+
+    mo_barrel = io_barrel.
+    mo_buffer = io_buffer.
+  ENDMETHOD.
+
+  METHOD hash.
+    DATA: ls_hash_def TYPE ty_hash_def.
+
+    mo_barrel->reset( ).
+
+    LOOP AT mt_hash_def INTO ls_hash_def.
+      mo_barrel->set( hash_function( ls_hash_def ) ).
+      mo_barrel->roll( ).
+    ENDLOOP.
+
+  ENDMETHOD.
+
+  METHOD hash_function.
+    DATA: lv_f TYPE f.
+
+* (a + F(b,c,d) + X[k]) <<< s
+
+    lv_f = mo_barrel->get( 0 ) +
+      func( iv_x = mo_barrel->get( 1 )
+            iv_y = mo_barrel->get( 2 )
+            iv_z = mo_barrel->get( 3 ) ) +
+      mo_buffer->get_word( is_def-word ) +
+      mv_add.
+
+    rv_result = overflow( lv_f ).
+    rv_result = shift( iv_input  = rv_result
+                       iv_places = is_def-shift ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS lcl_ff IMPLEMENTATION.
+
+  METHOD constructor.
+    super->constructor( io_barrel = io_barrel io_buffer = io_buffer ).
+
+    mt_hash_def = VALUE #(
+      ( word = 0 shift = 3 ) ( word = 1 shift = 7 ) ( word = 2 shift = 11 ) ( word = 3 shift = 19 )
+      ( word = 4 shift = 3 ) ( word = 5 shift = 7 ) ( word = 6 shift = 11 ) ( word = 7 shift = 19 )
+      ( word = 8 shift = 3 ) ( word = 9 shift = 7 ) ( word = 10 shift = 11 ) ( word = 11 shift = 19 )
+      ( word = 12 shift = 3 ) ( word = 13 shift = 7 ) ( word = 14 shift = 11 ) ( word = 15 shift = 19 ) ).
+
+    mv_add = '000000'.
+
+  ENDMETHOD.
+
+  METHOD func.
+* XY v not(X) Z
+
+    rv_result = ( iv_x BIT-AND iv_y ) BIT-OR ( ( BIT-NOT iv_x ) BIT-AND iv_z ).
+
+  ENDMETHOD.
+
+
+ENDCLASS.
+
+
+CLASS lcl_gg IMPLEMENTATION.
+
+  METHOD constructor.
+    super->constructor( io_barrel = io_barrel io_buffer = io_buffer ).
+
+    mt_hash_def = VALUE #(
+      ( word = 0 shift = 3 ) ( word = 4 shift = 5 ) ( word = 8 shift = 9 ) ( word = 12 shift = 13 )
+      ( word = 1 shift = 3 ) ( word = 5 shift = 5 ) ( word = 9 shift = 9 ) ( word = 13 shift = 13 )
+      ( word = 2 shift = 3 ) ( word = 6 shift = 5 ) ( word = 10 shift = 9 ) ( word = 14 shift = 13 )
+      ( word = 3 shift = 3 ) ( word = 7 shift = 5 ) ( word = 11 shift = 9 ) ( word = 15 shift = 13 ) ).
+
+    mv_add = '5A827999'.
+
+  ENDMETHOD.
+
+  METHOD func.
+* XY v XZ v YZ
+
+    rv_result =
+      ( iv_x BIT-AND iv_y ) BIT-OR
+      ( iv_x BIT-AND iv_z ) BIT-OR
+      ( iv_y BIT-AND iv_z ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS lcl_hh IMPLEMENTATION.
+
+  METHOD constructor.
+    super->constructor( io_barrel = io_barrel io_buffer = io_buffer ).
+
+    mt_hash_def = VALUE #(
+      ( word = 0 shift = 3 ) ( word = 8 shift = 9 ) ( word = 4 shift = 11 ) ( word = 12 shift = 15 )
+      ( word = 2 shift = 3 ) ( word = 10 shift = 9 ) ( word = 6 shift = 11 ) ( word = 14 shift = 15 )
+      ( word = 1 shift = 3 ) ( word = 9 shift = 9 ) ( word = 5 shift = 11 ) ( word = 13 shift = 15 )
+      ( word = 3 shift = 3 ) ( word = 11 shift = 9 ) ( word = 7 shift = 11 ) ( word = 15 shift = 15 ) ).
+
+    mv_add = '6ED9EBA1'.
+  ENDMETHOD.
+
+  METHOD func.
+* X xor Y xor Z
+
+    rv_result = ( iv_x BIT-XOR iv_y ) BIT-XOR iv_z.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/zcl_ntlm.clas.abap
+++ b/src/zcl_ntlm.clas.abap
@@ -20,10 +20,10 @@ CLASS zcl_ntlm DEFINITION
       RAISING
         cx_static_check .
   PROTECTED SECTION.
-*"* protected components of class ZCL_NTLM
-*"* do not include other source files here!!!
 
     TYPES:
+*"* protected components of class ZCL_NTLM
+*"* do not include other source files here!!!
       ty_byte2 TYPE x LENGTH 2 .
     TYPES:
       ty_byte4 TYPE x LENGTH 4 .
@@ -94,10 +94,10 @@ CLASS zcl_ntlm DEFINITION
         version     TYPE ty_byte8,
       END OF ty_type3 .
 
-    CONSTANTS c_message_type_1 TYPE xstring VALUE '01000000'. "#EC NOTEXT
-    CONSTANTS c_signature TYPE xstring VALUE '4E544C4D53535000'. "#EC NOTEXT
-    CONSTANTS c_message_type_2 TYPE xstring VALUE '02000000'. "#EC NOTEXT
-    CONSTANTS c_message_type_3 TYPE xstring VALUE '03000000'. "#EC NOTEXT
+    CONSTANTS c_message_type_1 TYPE xstring VALUE '01000000' ##NO_TEXT.
+    CONSTANTS c_signature TYPE xstring VALUE '4E544C4D53535000' ##NO_TEXT.
+    CONSTANTS c_message_type_2 TYPE xstring VALUE '02000000' ##NO_TEXT.
+    CONSTANTS c_message_type_3 TYPE xstring VALUE '03000000' ##NO_TEXT.
 
     CLASS-METHODS ntlm2_session_response
       IMPORTING
@@ -124,15 +124,18 @@ CLASS zcl_ntlm DEFINITION
         !iv_url          TYPE clike
         !iv_ssl_id       TYPE ssfapplssl
       RETURNING
-        VALUE(ri_client) TYPE REF TO if_http_client .
-    TYPE-POOLS abap .
+        VALUE(ri_client) TYPE REF TO if_http_client
+      RAISING
+        zcx_ntlm_error .
     CLASS-METHODS http_2
       IMPORTING
         !iv_authorization       TYPE string
         !ii_client              TYPE REF TO if_http_client
         !iv_ignore              TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rv_authorization) TYPE string .
+        VALUE(rv_authorization) TYPE string
+      RAISING
+        zcx_ntlm_error .
     CLASS-METHODS lmv2_response
       IMPORTING
         !iv_password       TYPE clike
@@ -194,7 +197,9 @@ CLASS zcl_ntlm DEFINITION
       IMPORTING
         !iv_msg        TYPE string
       RETURNING
-        VALUE(rs_data) TYPE ty_type1 .
+        VALUE(rs_data) TYPE ty_type1
+      RAISING
+        zcx_ntlm_protocol_error .
     CLASS-METHODS type_2_encode
       IMPORTING
         !is_data      TYPE ty_type2
@@ -205,7 +210,9 @@ CLASS zcl_ntlm DEFINITION
         !iv_msg        TYPE string
         !iv_oem        TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rs_data) TYPE ty_type3 .
+        VALUE(rs_data) TYPE ty_type3
+      RAISING
+        zcx_ntlm_protocol_error .
     CLASS-METHODS type_1_encode
       IMPORTING
         !is_data      TYPE ty_type1
@@ -213,10 +220,11 @@ CLASS zcl_ntlm DEFINITION
         VALUE(rv_msg) TYPE string .
     CLASS-METHODS type_2_decode
       IMPORTING
-        !iv_msg        TYPE string
-        !iv_oem        TYPE abap_bool DEFAULT abap_false
+                !iv_msg        TYPE string
+                !iv_oem        TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rs_data) TYPE ty_type2 .
+                VALUE(rs_data) TYPE ty_type2
+      RAISING   zcx_ntlm_protocol_error.
     CLASS-METHODS type_3_encode
       IMPORTING
         !is_data      TYPE ty_type3
@@ -281,8 +289,7 @@ CLASS ZCL_NTLM IMPLEMENTATION.
                        ii_client        = ri_client ).
 
     IF strlen( lv_value ) <= 5.
-      BREAK-POINT.
-      RETURN.
+      RAISE EXCEPTION TYPE zcx_ntlm_protocol_error.
     ENDIF.
 
 * decode type 2 message
@@ -334,8 +341,7 @@ CLASS ZCL_NTLM IMPLEMENTATION.
         http_processing_failed     = 3
         OTHERS                     = 4 ).
     IF sy-subrc <> 0.
-* todo
-      BREAK-POINT.
+      RAISE EXCEPTION TYPE zcx_ntlm_network_error.
     ENDIF.
 
     ri_client->response->get_header_fields( CHANGING fields = lt_fields ).
@@ -344,7 +350,7 @@ CLASS ZCL_NTLM IMPLEMENTATION.
       WITH KEY name = 'www-authenticate' value = 'NTLM'.    "#EC NOTEXT
     IF sy-subrc <> 0.
 * no NTML destination
-      BREAK-POINT.
+      RAISE EXCEPTION TYPE zcx_ntlm_protocol_error.
     ENDIF.
 
   ENDMETHOD.
@@ -374,8 +380,7 @@ CLASS ZCL_NTLM IMPLEMENTATION.
         http_processing_failed     = 3
         OTHERS                     = 4 ).
     IF sy-subrc <> 0.
-* todo
-      BREAK-POINT.
+      RAISE EXCEPTION TYPE zcx_ntlm_network_error.
     ENDIF.
 
     IF iv_ignore = abap_false.
@@ -385,7 +390,7 @@ CLASS ZCL_NTLM IMPLEMENTATION.
         WITH KEY name = 'www-authenticate'.                 "#EC NOTEXT
       IF sy-subrc <> 0.
 * no NTML destination
-        BREAK-POINT.
+        RAISE EXCEPTION TYPE zcx_ntlm_protocol_error.
       ENDIF.
 
       rv_authorization = <ls_field>-value.
@@ -592,7 +597,6 @@ CLASS ZCL_NTLM IMPLEMENTATION.
 
     IF iv_time IS INITIAL.
       lv_time = lcl_util=>since_epoc_hex( ).
-      WRITE: / 'ntlmv2 time', lv_time.
     ELSE.
       lv_time = iv_time.
     ENDIF.
@@ -649,11 +653,9 @@ CLASS ZCL_NTLM IMPLEMENTATION.
 
     DATA: lo_reader TYPE REF TO lcl_reader.
 
-
-    CREATE OBJECT lo_reader
-      EXPORTING
-        iv_value = iv_msg
-        iv_type  = c_message_type_1.
+    lo_reader = NEW #(
+      iv_value = iv_msg
+      iv_type  = c_message_type_1 ).
 
     rs_data-flags = lo_reader->flags( ).
 
@@ -681,10 +683,7 @@ CLASS ZCL_NTLM IMPLEMENTATION.
 
     DATA: lo_writer TYPE REF TO lcl_writer.
 
-
-    CREATE OBJECT lo_writer
-      EXPORTING
-        iv_type = c_message_type_1.
+    lo_writer = NEW #( iv_type = c_message_type_1 ).
 
     lo_writer->flags( is_data-flags ).
 
@@ -716,10 +715,9 @@ CLASS ZCL_NTLM IMPLEMENTATION.
     DATA: lo_reader TYPE REF TO lcl_reader.
 
 
-    CREATE OBJECT lo_reader
-      EXPORTING
-        iv_value = iv_msg
-        iv_type  = c_message_type_2.
+    lo_reader = NEW #(
+      iv_value = iv_msg
+      iv_type  = c_message_type_2 ).
 
 * target name
     rs_data-target_name = lo_reader->data_str( iv_oem ).
@@ -744,9 +742,7 @@ CLASS ZCL_NTLM IMPLEMENTATION.
     DATA: lo_writer TYPE REF TO lcl_writer.
 
 
-    CREATE OBJECT lo_writer
-      EXPORTING
-        iv_type = c_message_type_2.
+    lo_writer = NEW #( iv_type = c_message_type_2 ).
 
 * todo
 
@@ -759,13 +755,10 @@ CLASS ZCL_NTLM IMPLEMENTATION.
 
     DATA: lv_nonce TYPE ty_byte8.
 
-
-    WRITE: / 'server challenge', is_data2-challenge.
-
     IF iv_lmv2_nonce IS INITIAL.
       iv_lmv2_nonce = lcl_util=>random_nonce( ).
-      WRITE: / 'lmv2 nonce', iv_lmv2_nonce.
     ENDIF.
+
     rs_data3-lm_resp = lmv2_response( iv_password  = iv_password
                                       iv_domain    = iv_domain
                                       iv_username  = iv_username
@@ -774,8 +767,8 @@ CLASS ZCL_NTLM IMPLEMENTATION.
 
     IF iv_ntlmv2_nonce IS INITIAL.
       iv_ntlmv2_nonce = lcl_util=>random_nonce( ).
-      WRITE: / 'ntlmv2 nonce', iv_ntlmv2_nonce.
     ENDIF.
+
     rs_data3-ntlm_resp = ntlmv2_response( iv_password  = iv_password
                                           iv_username  = iv_username
                                           iv_target    = iv_domain
@@ -809,10 +802,9 @@ CLASS ZCL_NTLM IMPLEMENTATION.
     DATA: lo_reader TYPE REF TO lcl_reader.
 
 
-    CREATE OBJECT lo_reader
-      EXPORTING
-        iv_value = iv_msg
-        iv_type  = c_message_type_3.
+    lo_reader = NEW #(
+      iv_value = iv_msg
+      iv_type  = c_message_type_3 ).
 
 * LM challenge response
     rs_data-lm_resp = lo_reader->data_raw( ).
@@ -846,9 +838,7 @@ CLASS ZCL_NTLM IMPLEMENTATION.
     DATA: lo_writer TYPE REF TO lcl_writer.
 
 
-    CREATE OBJECT lo_writer
-      EXPORTING
-        iv_type = c_message_type_3.
+    lo_writer = NEW #( iv_type = c_message_type_3 ).
 
 * LM challenge response
     lo_writer->data_raw( is_data-lm_resp ).

--- a/src/zcl_ntlm.clas.locals_imp.abap
+++ b/src/zcl_ntlm.clas.locals_imp.abap
@@ -635,7 +635,8 @@ CLASS lcl_reader DEFINITION FINAL.
   PUBLIC SECTION.
     METHODS constructor
       IMPORTING iv_value TYPE string
-                iv_type  TYPE xstring.
+                iv_type  TYPE xstring
+      RAISING zcx_ntlm_protocol_error.
 
     METHODS flags
       RETURNING
@@ -643,13 +644,15 @@ CLASS lcl_reader DEFINITION FINAL.
 
     METHODS data_raw
       RETURNING
-        VALUE(rv_data) TYPE xstring.
+        VALUE(rv_data) TYPE xstring
+      RAISING zcx_ntlm_protocol_error.
 
     METHODS data_str
       IMPORTING
         iv_oem         TYPE abap_bool
       RETURNING
-        VALUE(rv_data) TYPE string.
+        VALUE(rv_data) TYPE string
+      RAISING zcx_ntlm_protocol_error.
 
     METHODS skip
       IMPORTING
@@ -692,12 +695,12 @@ CLASS lcl_reader IMPLEMENTATION.
     mv_original = lcl_convert=>base64_decode( iv_value ).
 
     IF xstrlen( mv_original ) < 8 OR mv_original(8) <> zcl_ntlm=>c_signature.
-      BREAK-POINT.
+      RAISE EXCEPTION TYPE zcx_ntlm_protocol_error.
     ENDIF.
     mv_current = mv_original+8.
 
     IF xstrlen( mv_current ) < 4 OR mv_current(4) <> iv_type.
-      BREAK-POINT.
+      RAISE EXCEPTION TYPE zcx_ntlm_protocol_error.
     ENDIF.
     mv_current = mv_current+4.
 
@@ -728,7 +731,7 @@ CLASS lcl_reader IMPLEMENTATION.
       RETURN.
     ENDIF.
     IF ls_fields-len <> ls_fields-maxlen.
-      BREAK-POINT.
+      RAISE EXCEPTION TYPE zcx_ntlm_protocol_error.
     ENDIF.
     rv_data = mv_original+ls_fields-offset(ls_fields-len).
 

--- a/src/zcl_ntlm.clas.testclasses.abap
+++ b/src/zcl_ntlm.clas.testclasses.abap
@@ -257,7 +257,11 @@ CLASS lcl_test IMPLEMENTATION.
              '0000000F574F524B53544154494F4E444F4D' &&
              '41494E'.
 
-    ls_data1 = zcl_ntlm=>type_1_decode( lcl_convert=>base64_encode( lv_raw ) ).
+    TRY.
+        ls_data1 = zcl_ntlm=>type_1_decode( lcl_convert=>base64_encode( lv_raw ) ).
+      CATCH zcx_ntlm_error.
+        cl_abap_unit_assert=>fail( quit = if_aunit_constants=>no ).
+    ENDTRY.
 
     cl_abap_unit_assert=>assert_equals(
         exp  = 'DOMAIN'
@@ -299,7 +303,12 @@ CLASS lcl_test IMPLEMENTATION.
                'RABPAE0AQQBJAE4AAgAMAEQATwBNAEEASQBOAAEADABTAEUAUgBWAEUAUgAEABQAZA' &&
                'BvAG0AYQBpAG4ALgBjAG8AbQADACIAcwBlAHIAdgBlAHIALgBkAG8AbQBhAGkAbgAu' &&
                'AGMAbwBtAAAAAAA='.
-    zcl_ntlm=>type_2_decode( lv_value ).
+
+    TRY.
+        zcl_ntlm=>type_2_decode( lv_value ).
+      CATCH zcx_ntlm_error.
+        cl_abap_unit_assert=>fail( quit = if_aunit_constants=>no ).
+    ENDTRY.
 
 
     lv_xstr = '4E544C4D53535000020000000C000C00' &&
@@ -308,7 +317,12 @@ CLASS lcl_test IMPLEMENTATION.
               '060070170000000F5300650072007600' &&
               '65007200'.
     lv_value = lcl_convert=>base64_encode( lv_xstr ).
-    zcl_ntlm=>type_2_decode( lv_value ).
+
+    TRY.
+        zcl_ntlm=>type_2_decode( lv_value ).
+      CATCH zcx_ntlm_error.
+        cl_abap_unit_assert=>fail( quit = if_aunit_constants=>no ).
+    ENDTRY.
 
 
   ENDMETHOD.                    "type_2_decode

--- a/src/zcx_ntlm_error.clas.abap
+++ b/src/zcx_ntlm_error.clas.abap
@@ -1,0 +1,28 @@
+class ZCX_NTLM_ERROR definition
+  public
+  inheriting from CX_STATIC_CHECK
+  create public .
+
+public section.
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like TEXTID optional
+      !PREVIOUS like PREVIOUS optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_NTLM_ERROR IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+TEXTID = TEXTID
+PREVIOUS = PREVIOUS
+.
+  endmethod.
+ENDCLASS.

--- a/src/zcx_ntlm_error.clas.xml
+++ b/src/zcx_ntlm_error.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_NTLM_ERROR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>NTLM Error</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_NTLM_ERROR</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcx_ntlm_network_error.clas.abap
+++ b/src/zcx_ntlm_network_error.clas.abap
@@ -1,0 +1,28 @@
+class ZCX_NTLM_NETWORK_ERROR definition
+  public
+  inheriting from ZCX_NTLM_ERROR
+  create public .
+
+public section.
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like TEXTID optional
+      !PREVIOUS like PREVIOUS optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_NTLM_NETWORK_ERROR IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+TEXTID = TEXTID
+PREVIOUS = PREVIOUS
+.
+  endmethod.
+ENDCLASS.

--- a/src/zcx_ntlm_network_error.clas.xml
+++ b/src/zcx_ntlm_network_error.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_NTLM_NETWORK_ERROR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>NTLM Network error</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_NTLM_NETWORK_ERROR</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcx_ntlm_protocol_error.clas.abap
+++ b/src/zcx_ntlm_protocol_error.clas.abap
@@ -1,0 +1,28 @@
+class ZCX_NTLM_PROTOCOL_ERROR definition
+  public
+  inheriting from ZCX_NTLM_ERROR
+  create public .
+
+public section.
+
+  methods CONSTRUCTOR
+    importing
+      !TEXTID like TEXTID optional
+      !PREVIOUS like PREVIOUS optional .
+protected section.
+private section.
+ENDCLASS.
+
+
+
+CLASS ZCX_NTLM_PROTOCOL_ERROR IMPLEMENTATION.
+
+
+  method CONSTRUCTOR.
+CALL METHOD SUPER->CONSTRUCTOR
+EXPORTING
+TEXTID = TEXTID
+PREVIOUS = PREVIOUS
+.
+  endmethod.
+ENDCLASS.

--- a/src/zcx_ntlm_protocol_error.clas.xml
+++ b/src/zcx_ntlm_protocol_error.clas.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_NTLM_PROTOCOL_ERROR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>NTLM Protocol Error</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCX_NTLM_PROTOCOL_ERROR</CLSNAME>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
* Fixed problem with whitespace

If the data for the MD4 hash is passed in in the form of a fixed length character field, trailing whitespace was not ignored.

* Refactored from macros to classes

* Update src/zcl_md4.clas.locals_imp.abap

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Update src/zcl_md4.clas.abap

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Update src/zcl_md4.clas.abap

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Update src/zcl_md4.clas.abap

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Pretty-printed

* Tweaked rules to allow modern abap

Increased ABAP version to allow the NEW operator for creating new objects.
Disabled the final class check, as it disallowed a local test class to inherit from another local class (for testing protected members)

* ABAPlint changes

* ABAPlint changes

* More ABAPlint fixes

* ABAPlint: Convert CREATE OBJECT

* Update src/zcl_ntlm.clas.abap

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Refreshed ZCL_DES

Removed macros
Made proper table literals
Moved table literals to class constructor
Removed large CASE-WHENs

* Update src/zcl_des.clas.abap

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Update src/zcl_des.clas.abap

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Fixed indentation in class constructor

* Linting

* Update src/zcl_des.clas.abap

Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>

* Linting

* Linting

* Linting

* Changed class variables prefix to M

* Linting

* Linting

* Changed from break points to exceptions

* Disabled descriptions-in-metadata check for exceptions

My version of SE80 only allows form-based editing of global class-based exceptions. So it is impossible to remove the description mentioned by ABAPlint

* Linting

Co-authored-by: Kasper Torp <kavt@novonordisk.com>
Co-authored-by: abaplint[bot] <24845621+abaplint[bot]@users.noreply.github.com>